### PR TITLE
bugfixed: mirror unconsistency for each key data etc

### DIFF
--- a/rising/transforms/functional/intensity.py
+++ b/rising/transforms/functional/intensity.py
@@ -283,12 +283,12 @@ def scale_by_value(data: torch.Tensor, value: float, out: Optional[torch.Tensor]
 def bezier_3rd_order(
     data: torch.Tensor, maxv: float = 1.0, minv: float = 0.0, out: Optional[torch.Tensor] = None
 ) -> torch.Tensor:
-    p0 = torch.zeros((1, 2))
-    p1 = torch.rand((1, 2))
-    p2 = torch.rand((1, 2))
-    p3 = torch.ones((1, 2))
+    p0 = torch.zeros((1, 2)).to(data.device)
+    p1 = torch.rand((1, 2)).to(data.device)
+    p2 = torch.rand((1, 2)).to(data.device)
+    p3 = torch.ones((1, 2)).to(data.device)
 
-    t = torch.linspace(0.0, 1.0, 1000).unsqueeze(1)
+    t = torch.linspace(0.0, 1.0, 1000).unsqueeze(1).to(data.device)
 
     points = (1 - t * t * t) * p0 + 3 * (1 - t) * (1 - t) * t * p1 + 3 * (1 - t) * t * t * p2 + t * t * t * p3
 
@@ -298,7 +298,7 @@ def bezier_3rd_order(
     xvals = points[:, 0]
     yvals = points[:, 1]
 
-    out_flat = Interp1d.apply(xvals, yvals, data.view(-1))
+    out_flat = Interp1d.apply(xvals, yvals, data.contiguous().view(-1))
 
     return out_flat.view(data.shape)
 

--- a/rising/transforms/kernel.py
+++ b/rising/transforms/kernel.py
@@ -107,8 +107,8 @@ class KernelTransform(AbstractTransform):
         Returns:
             dict: dict with transformed data
         """
-        # dtype, device = data[self.keys[0]].dtype, data[self.keys[0]].device
-        # self.to(dtype)
+        dtype, device = data[self.keys[0]].dtype, data[self.keys[0]].device
+        self.to(dtype)
         for key, padding_mode in zip(self.keys, self.padding_mode):
             inp_pad = F.pad(data[key], self.padding, mode=padding_mode)
 

--- a/rising/transforms/spatial.py
+++ b/rising/transforms/spatial.py
@@ -73,9 +73,10 @@ class Mirror(AbstractTransform):
             prob = self.prob
 
         seed = torch.random.get_rng_state()
+        dims = self.dims
         for key in self.keys:
             torch.random.set_rng_state(seed)
-            for dim, p in zip(self.dims, prob):
+            for dim, p in zip(dims, prob):
                 if torch.rand(1) < p:
                     data[key] = mirror(data[key], dim)
         return data


### PR DESCRIPTION
## Short Description

Please give a short summary of the main points of this PR
bugfixed: 1. rtr.Mirror(dims=DiscreteParameter([0, 1, 2]), keys=['raw', 'label'], prob=1.0), mirror operation will cause unconsistency between;
2. RandomBezierTransform: without contiguous, may cause crash.
...

## PR Checklist

### PR Implementer

This is a small checklist for the implementation details of this PR.
If you submit a PR, please look at these points (don't worry about the `RisingTeam`
and `Reviewer` workflows, the only purpose of those is to have a compact view of
the steps)

If there are any questions regarding code style or other conventions check out our
[summary](https://github.com/PhoenixDL/rising/blob/master/CONTRIBUTING.md).

- [ ] Implementation
- [ ] Docstrings & Typing
- [ ] Check `__all__` sections and `__init__`
- [ ] Unittests (look at the line coverage of your tests, the goal is 100%!)
- [ ] Update notebooks & documentation if necessary
- [ ] Pass all tests
- [ ] Add the checksum of the last implementation commit to the Changelog

### RisingTeam

<details>
  <summary>RisingTeam workflow</summary>

- [ ] Add pull request to project (optionally delete corresponding project note)
- [ ] Assign correct label (if you don't have permission to do this, someone will do it for you.
  Please make sure to communicate the current status of the pr.)
- [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if
  not already in description)

</details>

### Reviewer

<details>
  <summary>Reviewer workflow</summary>

- [ ] Do all tests pass? (Unittests, NotebookTests, Documentation)
- [ ] Does the implementation follow `rising` design conventions?
- [ ] Are the tests useful? (!!!) Are additional tests needed?
  Can you think of critical points which should be covered in an additional test?
- [ ] Optional: Check coverage locally / Check tests locally if GPU is necessary to execute

</details>
